### PR TITLE
drop the BS suffix from IBlockScholesOracle

### DIFF
--- a/contracts/IBlockScholesOracle.sol
+++ b/contracts/IBlockScholesOracle.sol
@@ -7,7 +7,7 @@ import {IFeedProviderBS} from "./IFeedProviderBS.sol";
  * @title IBlockScholesOracleBS
  * @notice the public interface for the Oracle as a whole
  */
-interface IBlockScholesOracleBS is IFeedProviderBS {
+interface IBlockScholesOracle is IFeedProviderBS {
     /**
      * @notice The feed parameters for the option price and SVI feeds -
      *         these should be abi encoded and passed in as the "other"


### PR DESCRIPTION
Drop the BS suffix as the interface name already contains the BlockScholes name