### PR TITLE
rename contracts with uniform BS suffix

### DIFF
--- a/contracts/ConstantsBS.sol
+++ b/contracts/ConstantsBS.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.24;
 
-library Constants {
+// Constants for identifying feeds used by the Block Scholes Oracle.
+library ConstantsBS {
     // Feed IDs
     uint32 internal constant FEED_ID_FUTURE = 1;
     uint32 internal constant FEED_ID_MODEL_PARAMS = 2;

--- a/contracts/IOracleBS.sol
+++ b/contracts/IOracleBS.sol
@@ -7,7 +7,7 @@ import {IFeedProviderBS} from "./IFeedProviderBS.sol";
  * @title IBlockScholesOracleBS
  * @notice the public interface for the Oracle as a whole
  */
-interface IBlockScholesOracle is IFeedProviderBS {
+interface IOracleBS is IFeedProviderBS {
     /**
      * @notice The feed parameters for the option price and SVI feeds -
      *         these should be abi encoded and passed in as the "other"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Solidity API
 
-## Constants
+## ConstantsBS
 
 ### FEED_ID_FUTURE
 
@@ -146,54 +146,6 @@ uint8 SVI_PARAM_M
 uint8 SVI_PARAM_SIGMA
 ```
 
-## IBlockScholesOracle
-
-the public interface for the Oracle as a whole
-
-### OptionParameters
-
-The feed parameters for the option price and SVI feeds -
-        these should be abi encoded and passed in as the "other"
-        feed parameters.
-
-```solidity
-struct OptionParameters {
-  int64 expiry;
-  int64 ivLevelValue;
-}
-```
-
-### RouteDoesNotExist
-
-```solidity
-error RouteDoesNotExist()
-```
-
-error emitted when a route does not exist for the specified
-        feed ID
-
-### FeedProviderDoesNotExist
-
-```solidity
-error FeedProviderDoesNotExist()
-```
-
-error emitted when a feed provider cannot be found for the
-        specified feed ID
-
-_this indicates a configuration error with how the route was set up_
-
-### PermissionDenied
-
-```solidity
-error PermissionDenied()
-```
-
-error emitted when a client does not have permission to access
-        the specified feed.
-
-_permissions are based on the feed ID and enumerable feed parameters_
-
 ## IFeedProviderBS
 
 _common interface for feed providers to implement_
@@ -250,4 +202,52 @@ _get the latest feed data_
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | [0] | struct IFeedProviderBS.FeedData | the latest feed data |
+
+## IOracleBS
+
+the public interface for the Oracle as a whole
+
+### OptionParameters
+
+The feed parameters for the option price and SVI feeds -
+        these should be abi encoded and passed in as the "other"
+        feed parameters.
+
+```solidity
+struct OptionParameters {
+  int64 expiry;
+  int64 ivLevelValue;
+}
+```
+
+### RouteDoesNotExist
+
+```solidity
+error RouteDoesNotExist()
+```
+
+error emitted when a route does not exist for the specified
+        feed ID
+
+### FeedProviderDoesNotExist
+
+```solidity
+error FeedProviderDoesNotExist()
+```
+
+error emitted when a feed provider cannot be found for the
+        specified feed ID
+
+_this indicates a configuration error with how the route was set up_
+
+### PermissionDenied
+
+```solidity
+error PermissionDenied()
+```
+
+error emitted when a client does not have permission to access
+        the specified feed.
+
+_permissions are based on the feed ID and enumerable feed parameters_
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockscholes/oracle-interface",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "scripts": {
     "build": "hardhat compile",
     "format": "prettier --write .",


### PR DESCRIPTION
Rename the following contracts to follow a uniform naming convention:

- Contracts -> ContractsBS
- IBlockScholesOracle -> IOracleBS