### PR TITLE
Roll out ARM runner_type workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,22 @@
 name: Solidity CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      runner_type:
+        description: "Runner type: 'self-hosted' (default) or 'github-hosted'"
+        required: false
+        type: choice
+        default: self-hosted
+        options:
+          - self-hosted
+          - github-hosted
   push:
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson((github.event.inputs.runner_type || 'self-hosted') == 'self-hosted' && '["self-hosted","ARM64"]' || '["arm-runner"]') }}
 
     strategy:
       matrix:
@@ -14,15 +24,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Cache Node.js modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,20 @@
 name: Publish Package to npmjs
 on:
+  workflow_dispatch:
+    inputs:
+      runner_type:
+        description: "Runner type: 'self-hosted' (default) or 'github-hosted'"
+        required: false
+        type: choice
+        default: self-hosted
+        options:
+          - self-hosted
+          - github-hosted
   release:
     types: [published]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson((github.event.inputs.runner_type || 'self-hosted') == 'self-hosted' && '["self-hosted","ARM64"]' || '["arm-runner"]') }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
     types: [published]
 jobs:
   build:
-    runs-on: ${{ fromJson((github.event.inputs.runner_type || 'self-hosted') == 'self-hosted' && '["self-hosted","ARM64"]' || '["arm-runner"]') }}
+    runs-on: ${{ fromJson(github.event_name == 'release' && '["ubuntu-latest"]' || ((github.event.inputs.runner_type || 'self-hosted') == 'self-hosted' && '["self-hosted","ARM64"]' || '["arm-runner"]')) }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- parameterize CI and publish workflows with runner_type for self-hosted ARM64 vs arm-runner
- update stale workflow action majors required by actionlint

## Validation
- actionlint -ignore arm-runner on modified workflows
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows now support manual triggers with a selectable runner type (self-hosted or hosted) and dynamic runner selection for release vs manual runs
  * Workflow action versions upgraded to newer releases for improved stability and performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->